### PR TITLE
WebWallet for integrating wallet-adapter & anchor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './instruction';
 export * as Transaction from './transaction';
 export * as Connection from './connection';
 export * as State from './state';
+export * as Wallet from './wallet';

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -1,0 +1,1 @@
+export * from './web';

--- a/src/wallet/web.ts
+++ b/src/wallet/web.ts
@@ -1,0 +1,44 @@
+import { web3, Wallet } from "@project-serum/anchor";
+import { SendOptions } from "../program";
+
+export default class WebWallet implements Wallet {
+  _signTransaction: (transaction: web3.Transaction) => Promise<web3.Transaction>;
+  _signAllTransactions: (transaction: web3.Transaction[]) => Promise<web3.Transaction[]>;
+  sendTransaction: (transaction: web3.Transaction, connection: web3.Connection, options?: SendOptions) => Promise<string>;
+  _publicKey: web3.PublicKey;
+  payer: web3.Keypair;
+
+  static fakeWallet() {
+    return new WebWallet(
+      web3.PublicKey.default,
+      (transaction: web3.Transaction = new web3.Transaction()) => {return Promise.resolve(transaction)},
+      (transaction: web3.Transaction[] = [new web3.Transaction()]) => {return Promise.resolve(transaction)},
+      () => {},
+    )
+  }
+
+  constructor(
+    publicKey: web3.PublicKey,
+    signTransaction: (transaction: web3.Transaction) => Promise<web3.Transaction>,
+    signAllTransactions: (transaction: web3.Transaction[]) => Promise<web3.Transaction[]>,
+    sendTransaction: any
+  ) {
+    this._publicKey = publicKey;
+    this._signTransaction = signTransaction;
+    this._signAllTransactions = signAllTransactions;
+    this.sendTransaction = sendTransaction;
+    this.payer = new web3.Keypair(); 
+  }
+
+  async signTransaction(tx: web3.Transaction): Promise<web3.Transaction> {
+    return this._signTransaction(tx);
+  }
+
+  async signAllTransactions(txs: web3.Transaction[]): Promise<web3.Transaction[]> {
+    return this._signAllTransactions(txs);
+  }
+
+  get publicKey(): web3.PublicKey {
+    return this._publicKey;
+  }
+}


### PR DESCRIPTION
This is used in conjunction with solana-labs/wallet-adapter to enable signing and sending of a transaction using the anchor Program class in sol-kit and whatever wallet extension the user picks through the wallet-adapter web UI.

Example: https://github.com/raindrop-studios/rain-redemptions/blob/3436c45c057dea87136444c3ff97357442278c1a/app/redemption-web/pages/index.tsx#L83

When you specify `asyncSigning` when creating a sol-kit program instance, it will use the async `signTransaction` calls under the hood when calling Program methods that send transactions rather then trying to sign with a wallet key pair loaded from known seeds. https://github.com/raindrop-studios/rain-redemptions/blob/3436c45c057dea87136444c3ff97357442278c1a/app/redemption-web/pages/index.tsx#L89

https://github.com/raindrop-studios/sol-kit/blob/7b662b2e56f7735d8a1c5613f78ef6efa415d498/src/transaction/send.ts#L111
https://github.com/raindrop-studios/sol-kit/blob/7b662b2e56f7735d8a1c5613f78ef6efa415d498/src/transaction/send.ts#L135

vs. with wallet and known seeds

https://github.com/raindrop-studios/sol-kit/blob/7b662b2e56f7735d8a1c5613f78ef6efa415d498/src/transaction/send.ts#L77
https://github.com/raindrop-studios/sol-kit/blob/7b662b2e56f7735d8a1c5613f78ef6efa415d498/src/transaction/send.ts#L101
